### PR TITLE
Euthanasia

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sisyphus "0.0.17"
+(defproject sisyphus "0.0.18"
   :description "Eternally execute tasks"
   :url "http://github.com/CovertLab/sisyphus"
   :license {:name "MIT License"

--- a/src/sisyphus/docker.clj
+++ b/src/sisyphus/docker.clj
@@ -19,6 +19,7 @@
    [com.spotify.docker.client.exceptions DockerException]
    [com.spotify.docker.client.messages
     ContainerConfig
+    ContainerInfo
     HostConfig]))
 
 (defn connect!
@@ -207,12 +208,20 @@
    (.removeContainer docker id)))
 
 (defn info
-  [^DockerClient docker id]
+  ^ContainerInfo [^DockerClient docker id]
   (.inspectContainer docker id))
 
 (defn exit-code
-  [info]
+  [^ContainerInfo info]
   (.exitCode (.state info)))
+
+(defn error-string
+  [^ContainerInfo info]
+  (.error (.state info)))
+
+(defn oom-killed?
+  [^ContainerInfo info]
+  (.oomKilled (.state info)))
 
 (defn exec-streams
      []

--- a/src/sisyphus/docker.clj
+++ b/src/sisyphus/docker.clj
@@ -155,6 +155,7 @@
     (mapcat #(string/split % #"\n") content)))
 
 (defn logs
+  "Return a lazy seq of log lines."
   [^DockerClient docker id]
   (logs-seq (docker-logs docker id)))
 

--- a/src/sisyphus/log.clj
+++ b/src/sisyphus/log.clj
@@ -83,7 +83,6 @@
 
 (defn- log-entry!
   "Log an entry. Flush it at `notice` severity and higher."
-  ; TODO(jerry): Log a sequence of entries at once from Docker output lines.
   [^Severity severity ^Payload payload]
   (let [{:keys [name resource]} *logger*
         entry

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -23,6 +23,7 @@
      * :exchange - name of the exchange to connect to (defaults to global exchange 'sisyphus-exchange')
      * :routing-key - routing key to use for messages (defaults to 'sisyphus-task')
    Returns a map containing all of the rabbitmq connection information."
+  ; TODO: try/finally to always close the channel and connection?
   [config]
   (let [config (merge default-config config)
         connection (lcore/connect (select-keys config config-keys))

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -265,15 +265,15 @@
 
     ; status :starting -> :running -> (:completed or :terminated-by-...)
     ;     or :terminate-when-ready -> :terminated-by-request.
-    (let [state-map (swap-vals! state assoc :status :running)]
-      (if (= (:status state-map) :starting)
+    (let [old-state-map (first (swap-vals! state assoc :status :running))]
+      (if (= (:status old-state-map) :starting)
         (do
           (doseq [line (docker/logs docker docker-id)]
             (swap! lines conj line)
             (log/info! line))
           (swap! state replace-if :status :running :completed))
 
-        (swap! state replace-if :status :terminate-when-ready (:action state-map)))
+        (swap! state replace-if :status :terminate-when-ready (:action old-state-map)))
 
       (let [end-nanos (System/nanoTime)
             _ (cancel-timer timer)

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -261,7 +261,7 @@
   log lines. Return a note to log with completion code (:completed = good),
   elapsed time, and the timeout parameter (to debug timeouts)."
   [{:keys [kafka docker state] :as sisy-state} task lines docker-id]
-  (let [timeout-millis (* (:timeout task default-timeout-seconds) 1000)
+  (let [timeout-millis (* (or (:timeout task) default-timeout-seconds) 1000)
         timer (task-timeout-timer timeout-millis sisy-state (:id task))
         start-nanos (System/nanoTime)]
     (docker/start! docker docker-id)

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -343,6 +343,7 @@
               (log/log! (if success? log/info log/error)
                         (str note
                              ", exit code " code
+                             (if (= code 137) " SIGKILL" "")
                              ", error string \"" error-string "\""
                              (if oom-killed? "; got out-of-memory (OOM) error" "")))
               (status! kafka task "container-exit" {:docker-id id :code code})

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -222,7 +222,7 @@
         task (:task new)
         docker-id (:docker-id new)]
     (when (and (= (:action new) :kill) (not= (:action old) :kill))
-      (log/debug! "terminating step" termination-status)
+      (log/debug! "terminating step..." termination-status)
       (docker/stop! docker docker-id)
       (log/notice! "STEP TERMINATED" termination-status)
       (status! kafka task "step-terminated" {:reason termination-status})
@@ -280,9 +280,9 @@
             _ (cancel-timer timer)
             elapsed-duration (Duration/ofNanos (- end-nanos start-nanos))
             timeout-duration (Duration/ofMillis timeout-millis)]
-        (str "ELAPSED: " (format-duration elapsed-duration)
-             "; " (full-name (:status @state))  ; completion reason
-             "; timeout parameter: " (format-duration timeout-duration))))))
+        (str "PROCESS " (full-name (:status @state))  ; completion reason
+             ", elapsed " (format-duration elapsed-duration)
+             ", timeout parameter " (format-duration timeout-duration))))))
 
 (defn perform-task!
   "Given sisy-state containing connections to cloud storage and a docker service,
@@ -342,8 +342,8 @@
                                 (not oom-killed?))]
               (log/log! (if success? log/info log/error)
                         (str note
-                             "; container exit code:" code
-                             "; error string: \"" error-string "\""
+                             ", exit code " code
+                             ", error string \"" error-string "\""
                              (if oom-killed? "; got out-of-memory (OOM) error" "")))
               (status! kafka task "container-exit" {:docker-id id :code code})
 

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -248,7 +248,7 @@
     (when (and (= (:action new) :kill) (not= (:action old) :kill))
       (log/debug! "terminating step..." termination-status)
       (docker/stop! docker docker-id)
-      (log/notice! "STEP TERMINATED" termination-status)
+      (log/notice! "step terminated" termination-status)
       (status! kafka task "step-terminated" {:reason termination-status})
       true)))
 
@@ -304,7 +304,7 @@
             _ (cancel-timer timer)
             elapsed-duration (Duration/ofNanos (- end-nanos start-nanos))
             timeout-duration (Duration/ofMillis timeout-millis)]
-        (str "PROCESS " (full-name (:status @state))  ; completion reason
+        (str "process " (full-name (:status @state))  ; completion reason
              ", elapsed " (format-duration elapsed-duration)
              ", timeout parameter " (format-duration timeout-duration))))))
 

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -337,13 +337,13 @@
                   oom-killed? (docker/oom-killed? info)
                   success? (and (= status :completed)
                                 (zero? code)
-                                (zero? (count error-string))  ; is this right?
+                                ; (zero? (count error-string))  ; is this right?
                                 (not oom-killed?))]
               (log/log! (if success? log/info log/error)
-                        note
-                        "; container exit code:" code
-                        "; error string: " error-string
-                        (if oom-killed? "; got out-of-memory (OOM) error" ""))
+                        (str note
+                             "; container exit code:" code
+                             "; error string: \"" error-string "\""
+                             (if oom-killed? "; got out-of-memory (OOM) error" "")))
               (status! kafka task "container-exit" {:docker-id id :code code})
 
               ; push the outputs to storage if the task succeeded; push stderr even on error

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -343,7 +343,7 @@
               (log/log! (if success? log/info log/error)
                         (str note
                              ", exit code " code
-                             (if (= code 137) " SIGKILL" "")
+                             (if (= code 137) " (SIGKILL)" "")
                              ", error string \"" error-string "\""
                              (if oom-killed? "; got out-of-memory (OOM) error" "")))
               (status! kafka task "container-exit" {:docker-id id :code code})

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -10,7 +10,13 @@
    [sisyphus.kafka :as kafka]
    [sisyphus.log :as log])
   (:import
+    [java.time Duration]
     [com.spotify.docker.client.exceptions DockerException]))
+
+(defn format-duration
+  "Format a java.time.Duration as a string like '1H26M12.345S'."
+  [^Duration duration]
+  (.substring (str duration) 2)) ; strip "PT" from the "PTnHnMnS" format
 
 (def full-name
   "Extract the string representation of the given keyword. This is an extension to the
@@ -174,16 +180,67 @@
        {:code code
         :log log}))))
 
+(defn make-timer
+  "Make a `future` as a timer that calls `f` in another thread. Cancelling it
+  can stop the timer but won't interrupt `f` midway."
+  [milliseconds f]
+  (future
+    (Thread/sleep milliseconds)
+    (future (f))))
+
+(defn cancel-timer
+  "Cancel the given timer, if possible."
+  [timer]
+  (future-cancel timer))
+
 (defn kill!
-  "Kill the task's docker process. Let perform-task! finish up."
-  [{:keys [docker kafka state]} reason]
-  (when-let [task (:task @state)
-             docker-id (:docker-id task)]
-    (log/debug! "terminating step" reason)
-    (docker/stop! docker docker-id)
-    (swap! state assoc-in [:task :docker-id] nil)  ; prevent double-kill
-    (log/notice! "STEP TERMINATED" reason)
-    (status! kafka task "step-terminated" {})))
+  "Kill the task's docker process and clear the state's docker-id to record that
+  it got killed and to prevent re-kill. (perform-task! will finish up soon.)"
+  ([{:keys [state] :as sisy-state} reason]
+   (kill! sisy-state reason (:docker-id (:task @state))))
+  ([{:keys [docker kafka state]} reason docker-id]
+   (let [task (:task @state)
+         current-docker-id (:docker-id task)]
+     (when (and current-docker-id (= current-docker-id docker-id))
+       (log/debug! "terminating step" reason)
+       (docker/stop! docker docker-id)
+       (swap! state assoc-in [:task :docker-id] nil)  ; prevent double-kill
+       (log/notice! "STEP TERMINATED" reason)
+       (status! kafka task "step-terminated" {:reason reason})))))
+
+(def default-timeout-millis (* 1000 60 60))
+
+(defn- task-timeout-timer
+  "Start a task-timeout timer for the given docker-id."
+  [milliseconds docker-id sisy-state]
+  (make-timer milliseconds #(kill! sisy-state "task timeout" docker-id)))
+
+(defn- run-command!
+  "Run the command inside the ready docker container, with a timeout, and append
+  all the log lines plus an elapsed time measurement."
+  [{:keys [kafka docker state] :as sisy-state} lines docker-id]
+  (let [task (:task @state)
+        timeout-millis (:timeout task default-timeout-millis)]
+    (status! kafka task "execution-start" {:docker-id docker-id})
+
+    (let [timer (task-timeout-timer timeout-millis docker-id sisy-state)
+          start-nanos (System/nanoTime)]
+      (docker/start! docker docker-id)
+
+      (doseq [line (docker/logs docker docker-id)]
+        (swap! lines conj line)
+        (log/info! line)) ; TODO(jerry): Detect stack tracebacks heuristically
+
+      (cancel-timer timer)
+
+      (let [end-nanos (System/nanoTime)
+            elapsed-duration (Duration/ofNanos (- end-nanos start-nanos))
+            timeout-duration (Duration/ofMillis timeout-millis)
+            cancelled? (not (get-in @state [:task :docker-id]))
+            note (str "ELAPSED " (format-duration elapsed-duration)
+                      (if cancelled? "; CANCELLED by the " " out of the ")
+                      (format-duration timeout-duration) " timeout")]
+        (swap! lines conj "" note)))))
 
 (defn perform-task!
   "Given a state containing a connection to both cloud storage and some docker service, 
@@ -194,15 +251,14 @@
    Run the container with the host's uid:gid, not as root, so the app has limited
    permissions on the host and its outputs can be deleted.
    ASSUMES: Every directory the app writes to within the container is world-writeable."
-  [{:keys [storage kafka docker config state]} task]
+  [{:keys [storage kafka docker config state] :as sisy-state} task]
   (try
     (let [root (get-in config [:local :root])
           input-root (str root "/inputs")
           output-root (str root "/outputs")
           inputs (find-locals! input-root (:inputs task))
           outputs (find-locals! output-root (:outputs task))
-          image (:image task)
-          command (:command task)]
+          image (:image task)]
 
       (try
         (status! kafka task "step-start" {})
@@ -216,7 +272,7 @@
               config {:image image
                       :user uid-gid
                       :mounts mounts
-                      :command command}
+                      :command (:command task)}
               lines (atom [])
               id (docker/create! docker config)]
 
@@ -225,12 +281,7 @@
             (log/info! "created container" id config)
             (status! kafka task "container-create" {:docker-id id :docker-config config})
 
-            (status! kafka task "execution-start" {:docker-id id})
-            (docker/start! docker id)
-
-            (doseq [line (docker/logs docker id)]
-              (swap! lines conj line)
-              (log/info! line)) ; TODO(jerry): Detect stack tracebacks heuristically
+            (run-command! sisy-state lines id)
 
             (let [code (docker/exit-code (docker/info docker id))]
               (log/log! (if (zero? code) log/debug log/error) "container exit code" code)

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -240,7 +240,8 @@
             note (str "ELAPSED " (format-duration elapsed-duration)
                       (if cancelled? "; CANCELLED by the " " out of the ")
                       (format-duration timeout-duration) " timeout")]
-        (swap! lines conj "" note)))))
+        (swap! lines conj "" note)
+        (log/info! note)))))
 
 (defn perform-task!
   "Given a state containing a connection to both cloud storage and some docker service, 


### PR DESCRIPTION
* Implement per-task timeout, reading a `:timeout` parameter in seconds from the task spec; default = 1 hour.
* Log the elapsed run time, whether it terminated by timeout, and the timeout parameter. This is useful feedback and needed to test the timeout feature. 

      PROCESS terminated-by-timeout, elapsed 1.562448734S, timeout parameter 1s, exit code 137 (SIGKILL), error string ""
      PROCESS completed, elapsed 1.562448734S, timeout parameter 1s, exit code 0, error string ""

* Fix #13 Each task can specify a time limit in seconds, default = 1 hour.
  * TODO: Pass the `timeout` parameter through Gaia.
* Fix #15 Make it work if Sisyphus gets a task-cancellation request when there's no docker container process to kill, i.e. while pulling the docker image and the task input files.
* TODO: Unconditionally push STDOUT + the completion log message like to a log dir. Push a requested STDOUT only on success, like other outputs.
* Check and log the container's completion code and docker `oom-killed?`. Log the docker `error-string`.
  * TODO: Use `error-string` as another failure indicator?
* Project version "0.0.18".

Code improvements:
* Make task.clj entirely responsible for its docker process.
* Partially disentangle three `state` things and disentangle task.clj vs. core.clj state.
* Don't mutate the task spec.
* Share the timer code and make cancelling a timer cancel the sleep without interrupting the delayed function.
* Fix some race conditions.