### PR TITLE
Accessing google cloud compute services

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,8 @@
                  [com.google.cloud/google-cloud-core "1.87.0"]
                  [com.google.cloud/google-cloud-logging "1.87.0"] ; do not exclude io.grpc/grpc-core io.grpc/grpc-api io.grpc/grpc-netty-shaded or else logging will fail to load classes
                  [com.google.cloud/google-cloud-storage "1.87.0"]
+                 [com.google.apis/google-api-services-compute "v1-rev214-1.25.0"]
+                 ;; [com.google.api-client/google-api-client "1.30.4"]
                  [com.novemberain/langohr "5.1.0"]
                  [spootnik/kinsky "0.1.22"]]
   :pedantic? false

--- a/src/sisyphus/cloud.clj
+++ b/src/sisyphus/cloud.clj
@@ -5,6 +5,14 @@
    [sisyphus.log :as log])
   (:import
    [java.io File FileInputStream]
+   [java.util Arrays]
+   [com.google.api.client.googleapis.auth.oauth2 GoogleCredential]
+   [com.google.api.client.googleapis.javanet GoogleNetHttpTransport]
+   [com.google.api.client.http HttpTransport]
+   [com.google.api.client.json JsonFactory]
+   [com.google.api.client.json.jackson2 JacksonFactory]
+   [com.google.api.services.compute Compute Compute$Builder]
+   [com.google.api.services.compute.model Instance InstanceList]
    [com.google.cloud.storage
     Storage StorageOptions StorageException
     Storage$BlobField
@@ -269,3 +277,52 @@
             relative-path (.substring remote-key prefix-length)
             local-path (join-path [path relative-path])]
         (download-blob! blob local-path)))))
+
+(defn create-compute-service
+  "Create an instance of com.google.api.services.compute.Compute to make requests with."
+  []
+  (let [transport (GoogleNetHttpTransport/newTrustedTransport)
+        factory (JacksonFactory/getDefaultInstance)
+        auth (into-array ["https://www.googleapis.com/auth/cloud-platform"])
+        credential (GoogleCredential/getApplicationDefault)
+        credential (if (.createScopedRequired credential)
+                     (.createScoped credential (Arrays/asList auth))
+                     credential)
+        builder (Compute$Builder. transport factory credential)]
+    (.setApplicationName builder "Gaia/0.0.1")
+    (.build builder)))
+
+(defn render-filter
+  "Render a map of options into the weird format that the compute instances api expects"
+  [instance-filter]
+  (string/join
+   " "
+   (map
+    (fn [[k v]]
+      (format
+       "(%s = %s)"
+       (name k)
+       (if (string? v)
+         (format "\"%s\"" v)
+         v)))
+    instance-filter)))
+
+(defn list-instances
+  "Given a compute service instance, project and zone for instances, return information on those
+  instances. Also accepts an optional `options` arg that could contain the following keys:
+      * :filter - a map of keys to values to filter the list of instances."
+  ([^Compute service project zone]
+   (list-instances service project zone {}))
+  ([^Compute service project zone options]
+   (let [request (.list (.instances service) project zone)]
+     (if-let [instance-filter (:filter options)]
+       (.setFilter request (render-filter instance-filter)))
+     (loop [response (.execute request)
+            instances []]
+       (let [items (.getItems response)
+             next (.getNextPageToken response)
+             expansion (concat instances items)]
+         (.setPageToken request next)
+         (if (and items next)
+           (recur (.execute request) expansion)
+           expansion))))))

--- a/src/sisyphus/cloud.clj
+++ b/src/sisyphus/cloud.clj
@@ -290,7 +290,7 @@
                      credential)
         builder (Compute$Builder. transport factory credential)]
     (.setApplicationName builder "Gaia/0.0.1")
-    (.build builder)))
+    ^Compute (.build builder)))
 
 (defn render-filter
   "Render a map of options into the weird format that the compute instances api expects"
@@ -302,9 +302,7 @@
       (format
        "(%s = %s)"
        (name k)
-       (if (string? v)
-         (format "\"%s\"" v)
-         v)))
+       (with-out-str (pr v))))
     instance-filter)))
 
 (defn list-instances


### PR DESCRIPTION
Turns out the google compute services have an entirely separate api than the storage services. I've added a few functions to allow us to access compute services and then use that access to list information about existing instances, along with the means to provide a filter for that list in terms of a map of filter options. This is going to be used in Gaia to detect if workers already exist, and if not, launch them. 

We could expand the scope of what compute services we access through this api (for instance, the launching of new instances which we are currently doing with a shell script), but for now we only need to list things. 