### PR TITLE
Using gce metadata to configure rabbit queue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [com.google.cloud/google-cloud-logging "1.87.0"] ; do not exclude io.grpc/grpc-core io.grpc/grpc-api io.grpc/grpc-netty-shaded or else logging will fail to load classes
                  [com.google.cloud/google-cloud-storage "1.87.0"]
                  [com.google.apis/google-api-services-compute "v1-rev214-1.25.0"]
-                 ;; [com.google.api-client/google-api-client "1.30.4"]
+                 [com.google.api-client/google-api-client "1.30.4"]
                  [com.novemberain/langohr "5.1.0"]
                  [spootnik/kinsky "0.1.22"]]
   :pedantic? false

--- a/src/sisyphus/base.clj
+++ b/src/sisyphus/base.clj
@@ -1,0 +1,47 @@
+(ns sisyphus.base
+  (:require
+   [clojure.java.io :as io])
+  (:import
+   [java.time Duration]))
+
+(defn format-duration
+  "Format a java.time.Duration as a string like '1H26M12.345S'."
+  [^Duration duration]
+  (.substring (str duration) 2)) ; strip "PT" from the "PTnHnMnS" format
+
+(def full-name
+  "Extract the string representation of the given keyword. This is an extension to the
+   built-in `name` function which fails to return the full string representation for
+   namespaced keywords."
+  (comp str symbol))
+
+(defn split-key
+  [key]
+  (let [full-key (full-name key)
+        colon (.indexOf full-key ":")]
+    [(.substring full-key 0 colon) (.substring full-key (inc colon))]))
+
+(defn write-lines!
+  "Write a sequence of lines to a file, adding a newline to each line. Like
+  `spit`, this opens f via io/writer, writes the lines, then closes f.
+  See clojure.java.io/writer for the possibilities for f. Options docs?"
+  [f lines & options]
+  (with-open [^java.io.Writer w (apply io/writer f options)]
+    (doseq [line lines]
+      (.write w ^String (str line "\n")))))
+
+(defn make-timer
+  "Make a `future` as a timer that waits then calls `f`. Cancelling it can stop
+  the timer but won't interrupt `f` midway (which could be bad for docker/stop!
+  or apoptosis) since it runs `f` in an independent thread."
+  [milliseconds f]
+  (future
+    (Thread/sleep milliseconds)
+    (future (f))))
+
+(defn cancel-timer
+  "Cancel a timer if possible. nil safe. Return true if this cancelled it."
+  [timer]
+  (and timer (future-cancel timer)))
+
+

--- a/src/sisyphus/cloud.clj
+++ b/src/sisyphus/cloud.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as string]
    [clojure.java.io :as io]
+   [sisyphus.base :as base]
    [sisyphus.log :as log])
   (:import
    [java.io File FileInputStream]
@@ -62,15 +63,9 @@
     (.substring path 0 (dec (.length path)))
     path))
 
-(defn split-key
-  [key]
-  (let [colon (.indexOf key ":")]
-    [(.substring key 0 colon)
-     (.substring key (inc colon))]))
-
 (defn key-path
   [key]
-  (let [[bucket path] (split-key key)
+  (let [[bucket path] (base/split-key key)
         parts (string/split path #"/+")]
     (cons bucket parts)))
 
@@ -113,7 +108,7 @@
 (defn partition-keys
   "Partition bucket:key path strings into existing and not existing paths."
   [{:keys [^Storage storage]} data]
-  (let [bids (map (comp blob-id split-key) data)
+  (let [bids (map (comp blob-id base/split-key) data)
         existence (.get storage bids)]
     (reduce
      (fn [[exist non] [key blob]]

--- a/src/sisyphus/core.clj
+++ b/src/sisyphus/core.clj
@@ -143,7 +143,12 @@
      4. defaults from ns rabbit/default-config"
   [config]
   (let [metadata (rabbit/rabbit-metadata)
-        rabbit-config (merge (:rabbit config) metadata (:options config))
+        rabbit-config
+        (merge
+         rabbit/default-config
+         (:rabbit config)
+         metadata
+         (:options config))
         config (assoc config :rabbit rabbit-config)
         state (connect! config)]
     (rabbit/start-consumer!

--- a/src/sisyphus/log.clj
+++ b/src/sisyphus/log.clj
@@ -32,6 +32,7 @@
            {:throw-exceptions false
             :headers
             {:metadata-flavor "Google"}})]
+      ;; returns status 404 if the metadata field is not set
       (if (= 200 (:status response))
         (:body response)))
     ;; nil communicates failure and lets the caller find the value another way.

--- a/src/sisyphus/log.clj
+++ b/src/sisyphus/log.clj
@@ -5,6 +5,7 @@
     [clj-http.client :as http])
   (:import
     [java.io PrintWriter StringWriter]
+    [java.net UnknownHostException]
     [java.util Collections]
     [com.google.cloud MonitoredResource MonitoredResource$Builder]
     [com.google.cloud.logging LogEntry LogEntry$Builder Logging LoggingOptions
@@ -30,8 +31,8 @@
        (str "http://metadata.google.internal/computeMetadata/v1/instance/" fieldname)
        {:headers
         {:metadata-flavor "Google"}}))
-    (catch Exception e
-      (println "not on gce or" fieldname "is not a metadata field"))))
+    (catch UnknownHostException e
+      (println "not on GCE or" fieldname "is not a metadata field"))))
 
 (def gce-instance-name
   (or (gce-metadata "name") "local"))

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -123,12 +123,11 @@
     (log/info! "rabbit message received:" message)))
 
 (defn rabbit-metadata
-  ([] (rabbit-metadata {}))
-  ([default]
-   (let [default (merge default-config default)]
-     {:exchange (log/gce-metadata "rabbit-exchange" (:exchange default))
-      :queue (log/gce-metadata "rabbit-queue" (:queue default))
-      :routing-key (log/gce-metadata "rabbit-routing-key" (:routing-key default))})))
+  []
+  (when-let [workflow (log/gce-metadata "name")]
+    {:exchange (str workflow "-exchange")
+     :queue (str workflow "-queue")
+     :routing-key (str workflow "-task")}))
 
 (def parse-options
   [["-q" "--queue QUEUE" "queue to subscribe to"

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -122,6 +122,14 @@
   (let [message (json/parse-string raw true)]
     (log/info! "rabbit message received:" message)))
 
+(defn rabbit-metadata
+  ([] (rabbit-metadata {}))
+  ([default]
+   (let [default (merge default-config default)]
+     {:exchange (log/gce-metadata "rabbit-exchange" (:exchange default))
+      :queue (log/gce-metadata "rabbit-queue" (:queue default))
+      :routing-key (log/gce-metadata "rabbit-routing-key" (:routing-key default))})))
+
 (def parse-options
   [["-q" "--queue QUEUE" "queue to subscribe to"
     :default "sisyphus-queue"]

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -123,11 +123,12 @@
     (log/info! "rabbit message received:" message)))
 
 (defn rabbit-metadata
-  []
-  (let [workflow (or (log/gce-metadata "attributes/workflow") "sisyphus")]
-    {:exchange (str workflow "-exchange")
-     :queue (str workflow "-queue")
-     :routing-key (str workflow "-task")}))
+  ([] (rabbit-metadata nil))
+  ([workflow]
+   (let [workflow (or workflow (log/gce-metadata "attributes/workflow") "sisyphus")]
+     {:exchange (str workflow "-exchange")
+      :queue (str workflow "-queue")
+      :routing-key (str workflow "-task")})))
 
 (def parse-options
   [["-q" "--queue QUEUE" "queue to subscribe to"

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -124,7 +124,7 @@
 
 (defn rabbit-metadata
   []
-  (when-let [workflow (log/gce-metadata "name")]
+  (let [workflow (or (log/gce-metadata "attributes/workflow") "sisyphus")]
     {:exchange (str workflow "-exchange")
      :queue (str workflow "-queue")
      :routing-key (str workflow "-task")}))

--- a/src/sisyphus/task.clj
+++ b/src/sisyphus/task.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.string :as string]
    [clojure.java.io :as io]
-   [clojure.java.shell :as shell]
    [cheshire.core :as json]
    [sisyphus.archive :as archive]
    [sisyphus.cloud :as cloud]
@@ -164,18 +163,13 @@
    kafka task status
    (assoc message :exception (.toString throwable)) :status-topic))
 
-(defn shell-out
-  [& tokens]
-  "Shell out for a single line of text."
-  (.trim (:out (apply shell/sh tokens))))
-
 (def uid-gid
   "The current process' uid:gid numbers. Pass this to Docker --user so the
   command will create files with the same ownership and also not run as root
   with too much host access. The only user and group info shared in/out of the
   container are these id numbers. This user and group don't even need to be
   created in the container."
-  (str (shell-out "id" "-u") ":" (shell-out "id" "-g")))
+  (str (log/shell-out "id" "-u") ":" (log/shell-out "id" "-g")))
 
 (defn- report-task-completion
   "Report task completion to Gaia and log it."


### PR DESCRIPTION
This PR enables Sisyphus to look to its own GCE instance metadata to configure which rabbit exchange, queue and routing key to use for consuming task messages. 

Currently this works in theory, but I am not getting results back from `log/gce-metadata` even though those metadata fields are set. Further investigation is necessary, so this PR is not yet ready to merge. 

One thing to point out is that the values for rabbit configuration are able to come from four different places, so I had to make a decision about the priority order for setting these values. Currently:

1. Command line options (won't be used on servers, but useful for testing)
2. GCE metadata fields (currently this is the request that is not working)
3. The config file at `resources/config/sisyphus.clj`
4. The default values defined in the `sisyphus.rabbit/default-config` ns. 