### PR TITLE
Sharing an exchange between all workflows

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sisyphus "0.0.22"
+(defproject sisyphus "0.0.23"
   :description "Eternally execute tasks"
   :url "http://github.com/CovertLab/sisyphus"
   :license {:name "MIT License"

--- a/src/sisyphus/rabbit.clj
+++ b/src/sisyphus/rabbit.clj
@@ -126,8 +126,7 @@
   ([] (rabbit-metadata nil))
   ([workflow]
    (let [workflow (or workflow (log/gce-metadata "attributes/workflow") "sisyphus")]
-     {:exchange (str workflow "-exchange")
-      :queue (str workflow "-queue")
+     {:queue (str workflow "-queue")
       :routing-key (str workflow "-task")})))
 
 (def parse-options


### PR DESCRIPTION
While configuring rabbit to accept task messages for workers, we want to customize the queue and routing-key, but not the exchange, which can be shared between all workflows. 

In addition, I did some command line munging so I can specify the workflow locally. 